### PR TITLE
Fix meta description; Add 浅草 雷5656会館

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -18,7 +18,7 @@
     %meta(property='og:type' content='activity')
     %meta(property='og:image' content="https://asakusarb.github.io/oedo08/#{image_path('og_image.png')}")
     %meta(name='twitter:site' content='@OedoRubyKaigi')
-    %meta(name='description' content='大江戸Ruby会議08 2020/02/11（火・祝）5F・6F ときわホール')
+    %meta(name='description' content='大江戸Ruby会議08 2020/02/11（火・祝）浅草 雷5656会館 5F・6F ときわホール')
     %meta(name='keywords' content='oedo, rubykaigi, 大江戸ruby会議, asakusa.rb, 08, 2020')
     %link{href: "/images/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180"}
     %link{href: "/images/favicon.ico", rel: "shortcut icon", type: "image/vnd.microsoft.icon"}


### PR DESCRIPTION
description に 「浅草 雷5656会館」が抜けていたのでした :bow:

![image](https://user-images.githubusercontent.com/341101/71259469-e0577900-237b-11ea-8615-78c24a578a0c.png)
