### PR TITLE
日本語名の「・」の前後の文字をツメて、長めの名前も大きく表示できるようにした

### DIFF
--- a/data/timetable.yml
+++ b/data/timetable.yml
@@ -41,7 +41,7 @@ events:
   name: 招待講演
   speakers:
   - id: tenderlove
-    name: あーろん・ぱたーそん
+    name: あーろ<span class="kerning">ん・</span>ぱたーそん
     presentation_title: TBD
     github_id: tenderlove
     twitter_id: tenderlove
@@ -175,7 +175,7 @@ events:
     twitter_id: okuramasafumi
     avatar_url: https://avatars3.githubusercontent.com/u/1012014
   - id: tagomoris2
-    name: 真・タゴモリス
+    name: <span class="kerning">真・</span>タゴモリス
     presentation_title: Joining Startups A to Z
     github_id: tagomoris
     twitter_id: tagomoris
@@ -190,7 +190,7 @@ events:
   name: 基調講演
   speakers:
   - id: searls
-    name: じゃすてぃん・さーるず
+    name: じゃす<span class="kerning">てぃん・</span>さーるず
     presentation_title: TBD
     github_id: searls
     twitter_id: searls

--- a/source/stylesheets/_timetable.css.sass
+++ b/source/stylesheets/_timetable.css.sass
@@ -233,9 +233,12 @@
     height: 90px
 
   &.is-long
-    font-size: 10px
+    font-size: 11px
     left: 3px
-    letter-spacing: -1.5px
+    letter-spacing: -1.2px
+
+  .kerning
+    letter-spacing: -3px
 
 .timetable__speaker-content
   padding: 5px


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/341101/73742976-e7521380-4790-11ea-8384-acc6c39f280f.png)

## After

![image](https://user-images.githubusercontent.com/341101/73743042-0c468680-4791-11ea-911e-0fbfe306f6f9.png)
